### PR TITLE
Fix package name in docs

### DIFF
--- a/website/docs/quick-start.md
+++ b/website/docs/quick-start.md
@@ -8,7 +8,7 @@ slug: /
 ## Installation
 
 ```
-yarn install formo
+yarn install @buildo/formo
 ```
 
 :::important


### PR DESCRIPTION
Now it's `formo`, should be `@buildo/formo`.