### PR TITLE
Validation on blur and on change

### DIFF
--- a/test/useFormo.test.ts
+++ b/test/useFormo.test.ts
@@ -396,6 +396,62 @@ describe("formo", () => {
           .issues
       ).toEqual(option.none);
     });
+
+    test("validateOnChange and validateOnBlur work", async () => {
+      const { result } = renderHook(() =>
+        useFormo(
+          {
+            initialValues: {
+              promoCode: "",
+            },
+            fieldValidators: constant({
+              promoCode: validators.minLength(1, "required"),
+            }),
+            validateOnBlur: false,
+            validateOnChange: false,
+          },
+          {
+            onSubmit: ({ promoCode }) => taskEither.right(promoCode),
+          }
+        )
+      );
+
+      await act(async () => {
+        await result.current.fieldProps("promoCode").onBlur();
+      });
+
+      expect(result.current.fieldProps("promoCode").value).toBe("");
+      expect(result.current.fieldProps("promoCode").issues).toEqual(
+        option.none
+      );
+
+      await act(async () => {
+        await result.current.fieldProps("promoCode").onChange("some value");
+      });
+
+      expect(result.current.fieldProps("promoCode").value).toBe("some value");
+      expect(result.current.fieldProps("promoCode").issues).toEqual(
+        option.none
+      );
+
+      await act(async () => {
+        await result.current.fieldProps("promoCode").onChange("");
+      });
+
+      expect(result.current.fieldProps("promoCode").value).toBe("");
+      expect(result.current.fieldProps("promoCode").issues).toEqual(
+        option.none
+      );
+
+      await act(async () => {
+        await result.current.handleSubmit();
+      });
+
+      expect(result.current.fieldProps("promoCode").value).toBe("");
+      expect(result.current.fieldProps("promoCode").issues).toEqual(
+        option.some(["required"])
+      );
+    });
   });
 
   describe("form validation", () => {


### PR DESCRIPTION
Backporting of parameters `validateOnBlur` and `validateOnChange` from [UCZ project](https://github.com/buildo/unicredit-cz-with-externals/pull/3095/commits/e82e4624465f07b88c1a3a3c413362ebdcf50ad0).

### Test plan
Performed automated testing.