### PR TITLE
#2836200 - Fix staleness bug

### DIFF
--- a/src/useFormo.ts
+++ b/src/useFormo.ts
@@ -388,12 +388,11 @@ export function useFormo<
   const setValues = (partialValues: Partial<Values>) => {
     dispatch({ type: "setValues", values: partialValues });
 
-    const newValues = { ...state.current.values, ...partialValues };
     if (validateOnChange) {
       pipe(
         partialValues as Values,
         record.traverseWithIndex(task.taskSeq)((key) =>
-          validateField(key, newValues)
+          validateField(key, state.current.values)
         )
       )();
     }
@@ -440,9 +439,8 @@ export function useFormo<
       value: state.current.values[name],
       onChange: (v: Values[K]) => {
         setValues({ [name]: v } as unknown as Partial<Values>);
-        const newValues = { ...state.current.values, [name]: v } as Values;
         if (validateOnChange) {
-          return validateField(name, newValues)();
+          return validateField(name, state.current.values)();
         } else {
           return Promise.resolve();
         }
@@ -704,10 +702,12 @@ export function useFormo<
                 const newValues = { [name]: updatedArray } as Partial<Values>;
                 setValues(newValues);
                 if (validateOnChange) {
-                  validateSubfield(name, index, subfieldName, {
-                    ...state.current.values,
-                    ...newValues,
-                  })();
+                  validateSubfield(
+                    name,
+                    index,
+                    subfieldName,
+                    state.current.values
+                  )();
                 }
               })
             );
@@ -749,7 +749,7 @@ export function useFormo<
             setValues(newValues);
             if (validateOnChange) {
               validateSubform<SK, K, V>(
-                { ...state.current.values, ...newValues } as V,
+                state.current.values as V,
                 index,
                 name
               )();
@@ -768,15 +768,11 @@ export function useFormo<
           array.deleteAt(index),
           option.map((updatedArray) => {
             setValues({ [name]: updatedArray } as Partial<Values>);
-            const newValues = {
-              ...state.current.values,
-              [name]: updatedArray,
-            } as Values;
             record.sequence(
               taskEither.getTaskValidation(
                 nonEmptyArray.getSemigroup<FieldError>()
               )
-            )(validateAllSubforms(newValues))();
+            )(validateAllSubforms(state.current.values))();
           })
         );
     }

--- a/src/useFormo.ts
+++ b/src/useFormo.ts
@@ -1,4 +1,4 @@
-import { Reducer, useEffect, useState } from "react";
+import { Reducer, useState } from "react";
 import { taskEither, record, option, array, nonEmptyArray, task } from "fp-ts";
 import { FieldProps } from "./FieldProps";
 import { pipe, constFalse, constant, constTrue } from "fp-ts/function";

--- a/src/useFormo.ts
+++ b/src/useFormo.ts
@@ -1,4 +1,4 @@
-import { useReducer, Reducer, useState } from "react";
+import { Reducer, useEffect, useState } from "react";
 import { taskEither, record, option, array, nonEmptyArray, task } from "fp-ts";
 import { FieldProps } from "./FieldProps";
 import { pipe, constFalse, constant, constTrue } from "fp-ts/function";
@@ -8,6 +8,7 @@ import { Validator } from "./Validator";
 import { sequenceS } from "fp-ts/Apply";
 import { TaskEither } from "fp-ts/TaskEither";
 import { IO } from "fp-ts/lib/IO";
+import { useRefReducer } from "./useRefReducer";
 
 type ComputedFieldProps<V, Label, Issues> = Pick<
   FieldProps<V, Label, Issues>,
@@ -295,11 +296,9 @@ type UseFormReturn<
 type ValidatorErrorType<
   Values extends Record<string, unknown>,
   V extends Partial<FieldValidators<Values>>
-> = V extends Partial<
-  {
-    [k in keyof Values]: Validator<Values[k], unknown, infer E>;
-  }
->
+> = V extends Partial<{
+  [k in keyof Values]: Validator<Values[k], unknown, infer E>;
+}>
   ? E
   : null;
 
@@ -379,18 +378,24 @@ export function useFormo<
     ) as FieldArrayTouched,
   };
 
-  const [
-    {
-      values,
-      isSubmitting,
-      touched,
-      errors,
-      formErrors,
-      fieldArrayErrors,
-      fieldArrayTouched,
-    },
-    dispatch,
-  ] = useReducer<
+  // const [
+  //   {
+  //     values,
+  //     isSubmitting,
+  //     touched,
+  //     errors,
+  //     formErrors,
+  //     fieldArrayErrors,
+  //     fieldArrayTouched,
+  //   },
+  //   dispatch,
+  // ] = useReducer<
+  //   Reducer<
+  //     FormState<Values, FormErrors, FieldError>,
+  //     FormAction<Values, FormErrors, FieldError>
+  //   >
+  // >(formReducer, initialState);
+  const [state, dispatch] = useRefReducer<
     Reducer<
       FormState<Values, FormErrors, FieldError>,
       FormAction<Values, FormErrors, FieldError>
@@ -400,7 +405,7 @@ export function useFormo<
   const setValues = (partialValues: Partial<Values>) => {
     dispatch({ type: "setValues", values: partialValues });
 
-    const newValues = { ...values, ...partialValues };
+    const newValues = { ...state.current.values, ...partialValues };
     if (validateOnChange) {
       pipe(
         partialValues as Values,
@@ -414,7 +419,9 @@ export function useFormo<
   const setTouched = (partialTouched: Partial<Touched>) => {
     const partialTouchedChanged = pipe(
       partialTouched,
-      record.filterWithIndex((k, isTouch) => touched[k] !== isTouch)
+      record.filterWithIndex(
+        (k, isTouch) => state.current.touched[k] !== isTouch
+      )
     ) as Partial<Touched>;
 
     if (!record.size(partialTouchedChanged)) {
@@ -428,7 +435,7 @@ export function useFormo<
     k: K,
     newErrors: Option<NonEmptyArray<FieldError>>
   ) => {
-    if (option.isNone(errors[k]) && option.isNone(newErrors)) {
+    if (option.isNone(state.current.errors[k]) && option.isNone(newErrors)) {
       return;
     }
 
@@ -436,7 +443,7 @@ export function useFormo<
   };
 
   const setFormErrors = (errors: Option<FormErrors>) => {
-    if (option.isNone(formErrors) && option.isNone(errors)) {
+    if (option.isNone(state.current.formErrors) && option.isNone(errors)) {
       return;
     }
 
@@ -448,10 +455,10 @@ export function useFormo<
   ): ComputedFieldProps<Values[K], Label, NonEmptyArray<FieldError>> => {
     return {
       name,
-      value: values[name],
+      value: state.current.values[name],
       onChange: (v: Values[K]) => {
-        setValues(({ [name]: v } as unknown) as Partial<Values>);
-        const newValues = { ...values, [name]: v } as Values;
+        setValues({ [name]: v } as unknown as Partial<Values>);
+        const newValues = { ...state.current.values, [name]: v } as Values;
         if (validateOnChange) {
           return validateField(name, newValues)();
         } else {
@@ -459,19 +466,19 @@ export function useFormo<
         }
       },
       onBlur: () => {
-        setTouched(({ [name]: true } as unknown) as Partial<Touched>);
+        setTouched({ [name]: true } as unknown as Partial<Touched>);
         if (validateOnBlur) {
-          return validateField(name, values)();
+          return validateField(name, state.current.values)();
         } else {
           return Promise.resolve();
         }
       },
       issues: pipe(
-        errors[name],
-        option.filter(() => touched[name])
+        state.current.errors[name],
+        option.filter(() => state.current.touched[name])
       ),
-      isTouched: touched[name],
-      disabled: isSubmitting,
+      isTouched: state.current.touched[name],
+      disabled: state.current.isSubmitting,
     };
   };
 
@@ -636,10 +643,13 @@ export function useFormo<
 
   const setAllTouched = () => {
     setTouched(
-      (pipe(values, record.map(constTrue)) as unknown) as Partial<Touched>
+      pipe(
+        state.current.values,
+        record.map(constTrue)
+      ) as unknown as Partial<Touched>
     );
     pipe(
-      arrayValues(values),
+      arrayValues(state.current.values),
       record.mapWithIndex((field, v) =>
         pipe(
           v,
@@ -683,7 +693,7 @@ export function useFormo<
     >) => {
       return (subfieldName) => {
         const isTouched = pipe(
-          fieldArrayTouched[name][index],
+          state.current.fieldArrayTouched[name][index],
           option.fromNullable,
           option.chainNullableK((e) => e[subfieldName]),
           option.exists((e) => !!e)
@@ -691,23 +701,29 @@ export function useFormo<
 
         return {
           name: `${namePrefix(index)}.${subfieldName}`,
-          value: (values as V)[name][index][subfieldName] as V[K][number][SK],
+          value: (state.current.values as V)[name][index][
+            subfieldName
+          ] as V[K][number][SK],
           onChange: (value: V[K][number][SK]) => {
             pipe(
-              (values as V)[name][index] as V[K][number],
+              (state.current.values as V)[name][index] as V[K][number],
               record.updateAt(subfieldName, value),
               option.chain((value) =>
                 array.updateAt(
                   index,
                   value
-                )(values[name] as Array<Record<SK, V[K][number][SK]>>)
+                )(
+                  state.current.values[name] as Array<
+                    Record<SK, V[K][number][SK]>
+                  >
+                )
               ),
               option.map((updatedArray) => {
                 const newValues = { [name]: updatedArray } as Partial<Values>;
                 setValues(newValues);
                 if (validateOnChange) {
                   validateSubfield(name, index, subfieldName, {
-                    ...values,
+                    ...state.current.values,
                     ...newValues,
                   })();
                 }
@@ -724,14 +740,14 @@ export function useFormo<
             });
           },
           issues: pipe(
-            fieldArrayErrors[name][index],
+            state.current.fieldArrayErrors[name][index],
             option.fromNullable,
             option.chain((e) => option.fromNullable(e[subfieldName])),
             option.flatten,
             option.filter(() => isTouched)
           ),
           isTouched,
-          disabled: isSubmitting,
+          disabled: state.current.isSubmitting,
         };
       };
     };
@@ -745,13 +761,13 @@ export function useFormo<
           array.updateAt(
             index,
             elementValues
-          )(values[name] as Array<Record<SK, V[K][number][SK]>>),
+          )(state.current.values[name] as Array<Record<SK, V[K][number][SK]>>),
           option.map((updatedArray) => {
             const newValues = { [name]: updatedArray } as Partial<Values>;
             setValues(newValues);
             if (validateOnChange) {
               validateSubform<SK, K, V>(
-                { ...values, ...newValues } as V,
+                { ...state.current.values, ...newValues } as V,
                 index,
                 name
               )();
@@ -766,12 +782,12 @@ export function useFormo<
     >(index: number): () => void {
       return () =>
         pipe(
-          (values as V)[name],
+          (state.current.values as V)[name],
           array.deleteAt(index),
           option.map((updatedArray) => {
             setValues({ [name]: updatedArray } as Partial<Values>);
             const newValues = {
-              ...values,
+              ...state.current.values,
               [name]: updatedArray,
             } as Values;
             record.sequence(
@@ -783,19 +799,14 @@ export function useFormo<
         );
     }
 
-    const items: FieldArray<
-      Values,
-      K,
-      Label,
-      FieldError
-    >["items"] = (values as ArrayRecord<Values, string>)[name].map(
-      (_value, index) => ({
-        fieldProps: fieldProps(index),
-        onChangeValues: onChangeValues(index),
-        remove: remove(index),
-        namePrefix: namePrefix(index),
-      })
-    );
+    const items: FieldArray<Values, K, Label, FieldError>["items"] = (
+      state.current.values as ArrayRecord<Values, string>
+    )[name].map((_value, index) => ({
+      fieldProps: fieldProps(index),
+      onChangeValues: onChangeValues(index),
+      remove: remove(index),
+      namePrefix: namePrefix(index),
+    }));
 
     const insertAt: FieldArray<Values, K, Label, FieldError>["insertAt"] = <
       SK extends keyof ArrayRecordValues<Values> & string,
@@ -805,7 +816,7 @@ export function useFormo<
       value: V[K][number]
     ) => {
       pipe(
-        (values as V)[name],
+        (state.current.values as V)[name],
         array.insertAt(index, value),
         option.map((updatedArray) => {
           setValues({ [name]: updatedArray } as Partial<Values>);
@@ -818,7 +829,7 @@ export function useFormo<
       V extends ArrayRecord<Values, SK>
     >(
       value: V[K][number]
-    ) => insertAt<SK, V>((values as V)[name].length, value);
+    ) => insertAt<SK, V>((state.current.values as V)[name].length, value);
 
     return {
       items,
@@ -834,6 +845,7 @@ export function useFormo<
       onSubmit(values),
       taskEither.bimap(
         (errors) => {
+          console.log(errors);
           setFormErrors(option.some(errors));
         },
         () => {
@@ -849,7 +861,10 @@ export function useFormo<
       setSubmissionCount((count) => count + 1);
     }),
     () =>
-      pipe(validateAllFields(values), taskEither.chainW(validateFormAndSubmit)),
+      pipe(
+        validateAllFields(state.current.values),
+        taskEither.chainW(validateFormAndSubmit)
+      ),
     () =>
       taskEither.rightIO(() => {
         dispatch({ type: "setSubmitting", isSubmitting: false });
@@ -861,15 +876,15 @@ export function useFormo<
   };
 
   return {
-    values,
+    values: state.current.values,
     setValues,
     setTouched,
     fieldProps,
     handleSubmit,
-    isSubmitting,
+    isSubmitting: state.current.isSubmitting,
     fieldArray,
-    formErrors,
-    fieldErrors: errors,
+    formErrors: state.current.formErrors,
+    fieldErrors: state.current.errors,
     resetForm,
     submissionCount,
   };

--- a/src/useFormo.ts
+++ b/src/useFormo.ts
@@ -378,23 +378,6 @@ export function useFormo<
     ) as FieldArrayTouched,
   };
 
-  // const [
-  //   {
-  //     values,
-  //     isSubmitting,
-  //     touched,
-  //     errors,
-  //     formErrors,
-  //     fieldArrayErrors,
-  //     fieldArrayTouched,
-  //   },
-  //   dispatch,
-  // ] = useReducer<
-  //   Reducer<
-  //     FormState<Values, FormErrors, FieldError>,
-  //     FormAction<Values, FormErrors, FieldError>
-  //   >
-  // >(formReducer, initialState);
   const [state, dispatch] = useRefReducer<
     Reducer<
       FormState<Values, FormErrors, FieldError>,
@@ -446,7 +429,6 @@ export function useFormo<
     if (option.isNone(state.current.formErrors) && option.isNone(errors)) {
       return;
     }
-
     dispatch({ type: "setFormError", errors });
   };
 
@@ -845,7 +827,6 @@ export function useFormo<
       onSubmit(values),
       taskEither.bimap(
         (errors) => {
-          console.log(errors);
           setFormErrors(option.some(errors));
         },
         () => {
@@ -874,7 +855,6 @@ export function useFormo<
   const resetForm: IO<void> = () => {
     dispatch({ type: "reset", state: initialState });
   };
-
   return {
     values: state.current.values,
     setValues,

--- a/src/useRefReducer.ts
+++ b/src/useRefReducer.ts
@@ -2,6 +2,7 @@ import {
   MutableRefObject,
   useCallback,
   useEffect,
+  useReducer,
   useRef,
   useState,
 } from "react";
@@ -38,13 +39,13 @@ export const useRefReducer: <R extends RefReducer<any, any>>(
   initialState
 ) => {
   const state = useRef(initialState);
-  const [refresh, refreshHook] = useState(false);
+  const [_, forceUpdate] = useReducer((x) => x + 1, 0);
 
   const setState: <R extends RefReducer<any, any>>(
     action: RefReducerAction<R>
   ) => void = (action) => {
     state.current = refReducer(state.current, action);
-    refreshHook(!refresh);
+    forceUpdate();
   };
 
   const dispatch = useCallback(setState, [refReducer]);

--- a/src/useRefReducer.ts
+++ b/src/useRefReducer.ts
@@ -1,0 +1,39 @@
+import { MutableRefObject, useCallback, useEffect, useRef } from "react";
+
+type Dispatch<A> = (value: A) => void;
+
+type RefReducer<S, A> = (prevState: S, action: A) => S;
+
+type RefReducerState<R extends RefReducer<any, any>> = R extends RefReducer<
+  infer S,
+  any
+>
+  ? S
+  : never;
+
+type RefReducerAction<R extends RefReducer<any, any>> = R extends RefReducer<
+  any,
+  infer A
+>
+  ? A
+  : never;
+
+export const useRefReducer: <R extends RefReducer<any, any>>(
+  refReducer: R,
+  initialState: RefReducerState<R>
+) => [MutableRefObject<RefReducerState<R>>, Dispatch<RefReducerAction<R>>] = (
+  refReducer,
+  initialState
+) => {
+  const state = useRef(initialState);
+
+  const setState: <R extends RefReducer<any, any>>(
+    action: RefReducerAction<R>
+  ) => void = (action) => {
+    state.current = refReducer(state.current, action);
+  };
+
+  const dispatch = useCallback(setState, [refReducer]);
+
+  return [state, dispatch];
+};

--- a/src/useRefReducer.ts
+++ b/src/useRefReducer.ts
@@ -1,4 +1,10 @@
-import { MutableRefObject, useCallback, useEffect, useRef } from "react";
+import {
+  MutableRefObject,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
 
 type Dispatch<A> = (value: A) => void;
 
@@ -18,6 +24,12 @@ type RefReducerAction<R extends RefReducer<any, any>> = R extends RefReducer<
   ? A
   : never;
 
+/*
+ * This reducer is a combination of standard useReducer and useRef.
+ * It allows you to use a reducer with a mutable ref, avoiding staleness issues on function closures.
+ * The returned state does not change on each render, but its .current property does.
+ * Differently from useRef, this hook re-renders when the state changes.
+ */
 export const useRefReducer: <R extends RefReducer<any, any>>(
   refReducer: R,
   initialState: RefReducerState<R>
@@ -26,11 +38,13 @@ export const useRefReducer: <R extends RefReducer<any, any>>(
   initialState
 ) => {
   const state = useRef(initialState);
+  const [refresh, refreshHook] = useState(false);
 
   const setState: <R extends RefReducer<any, any>>(
     action: RefReducerAction<R>
   ) => void = (action) => {
     state.current = refReducer(state.current, action);
+    refreshHook(!refresh);
   };
 
   const dispatch = useCallback(setState, [refReducer]);

--- a/test/useFormo.test.ts
+++ b/test/useFormo.test.ts
@@ -1,7 +1,7 @@
 import { renderHook, act } from "@testing-library/react-hooks";
 import { useFormo, validators } from "../src";
 import { constant, pipe } from "fp-ts/function";
-import { nonEmptyArray, option, taskEither } from "fp-ts";
+import { nonEmptyArray, option, task, taskEither } from "fp-ts";
 import { Option } from "fp-ts/Option";
 
 describe("formo", () => {
@@ -123,6 +123,36 @@ describe("formo", () => {
     expect(
       result.current.fieldArray("apples").items[0].fieldProps("quantity").value
     ).toBe(10);
+  });
+
+  test("it works without referring to staleness state", () => {
+    const { result } = renderHook(() =>
+      useFormo(
+        {
+          initialValues: {
+            city: "Milan",
+          },
+          fieldValidators: constant({}),
+        },
+        {
+          onSubmit: () => taskEither.of(null),
+        }
+      )
+    );
+
+    expect(result.current.fieldProps("city").value).toBe("Milan");
+    expect(result.current.fieldProps("city").isTouched).toBe(false);
+
+    act(() => {
+      result.current.setTouched({ city: true });
+      expect(result.current.fieldProps("city").isTouched).toBe(true);
+    });
+
+    act(() => {
+      result.current.setValues({ city: "Rome" });
+      expect(result.current.fieldProps("city").value).toBe("Rome");
+      expect(result.current.values.city).toBe("Rome");
+    });
   });
 
   describe("field validations", () => {

--- a/test/useFormo.test.ts
+++ b/test/useFormo.test.ts
@@ -126,6 +126,7 @@ describe("formo", () => {
   });
 
   test("handleSubmit does not refer to stale values", async () => {
+    const onSubmit = jest.fn(() => taskEither.of(null));
     const { result } = renderHook(() =>
       useFormo(
         {
@@ -135,10 +136,7 @@ describe("formo", () => {
           fieldValidators: constant({}),
         },
         {
-          onSubmit: (values) => {
-            expect(values.city).toBe("Rome");
-            return taskEither.of(null);
-          },
+          onSubmit,
         }
       )
     );
@@ -149,6 +147,9 @@ describe("formo", () => {
       result.current.setValues({ city: "Rome" });
       result.current.handleSubmit();
     });
+
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+    expect(onSubmit).toHaveBeenCalledWith({ city: "Rome" });
   });
 
   describe("field validations", () => {

--- a/test/useFormo.test.ts
+++ b/test/useFormo.test.ts
@@ -125,7 +125,7 @@ describe("formo", () => {
     ).toBe(10);
   });
 
-  test("it works without referring to staleness state", () => {
+  test("handleSubmit does not refer to stale values", async () => {
     const { result } = renderHook(() =>
       useFormo(
         {
@@ -135,23 +135,19 @@ describe("formo", () => {
           fieldValidators: constant({}),
         },
         {
-          onSubmit: () => taskEither.of(null),
+          onSubmit: (values) => {
+            expect(values.city).toBe("Rome");
+            return taskEither.of(null);
+          },
         }
       )
     );
 
     expect(result.current.fieldProps("city").value).toBe("Milan");
-    expect(result.current.fieldProps("city").isTouched).toBe(false);
 
-    act(() => {
-      result.current.setTouched({ city: true });
-      expect(result.current.fieldProps("city").isTouched).toBe(true);
-    });
-
-    act(() => {
+    await act(async () => {
       result.current.setValues({ city: "Rome" });
-      expect(result.current.fieldProps("city").value).toBe("Rome");
-      expect(result.current.values.city).toBe("Rome");
+      result.current.handleSubmit();
     });
   });
 


### PR DESCRIPTION
Closes [#2836200](https://buildo.kaiten.io/space/35729/card/2836200)

# Approach

Instead of the  standard `useReducer`, a custom `useRefReducer` is used to have a `MutableObjectRef` as state.  In this way internal functions do not close on stale values, but always refer to the current values.

As a drawback, accessing the state internally to `useFormo` requires accessing the `.current` property, but this is transparent to the end-user. On the other hand, code blocks for computing the future `newValues` are no longer required as the `.current` values are always up-to-date.

Another drawback was that, using a reference, the `useFormo` hook didn't re-render itself when necessary, causing accessing the returned properties such as `.formErrors` refer to stale values. To solve this issue, the `useRefReducer` was updated to trigger a re-render when the `.current` property changes. In this way, the hook always re-render when the state changes (as default for classic hooks such as `useReducer` or `useState`). As a result, either the properties and the functions returned by `useFormo` refer to the correct values accordingly to the hook rendering.

# Test Plan

Add a test to verify that `handleSubmit` does no longer refer to stale values.

![image](https://user-images.githubusercontent.com/16003164/144628048-0d1e525c-a80b-4b10-b26c-14dda5d34d36.png)
