### PR TITLE
#18: formErrors is not (always?) cleared after submitting

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@buildo/formo",
-  "version": "2.0.0-beta.9",
+  "version": "2.0.0",
   "main": "lib/index.js",
   "license": "MIT",
   "files": [

--- a/src/useFormo.ts
+++ b/src/useFormo.ts
@@ -876,6 +876,7 @@ export function useFormo<
 
   async function handleSubmit(): Promise<Result<unknown, unknown>> {
     setAllTouched();
+    setFormErrors(undefined);
     dispatch({ type: "setSubmitting", isSubmitting: true });
     setSubmissionCount((count) => count + 1);
     try {


### PR DESCRIPTION
Closes #18

Published as version `@buildo/formo@2.0.1-0`

## Test Plan

### tests performed

see the added unit test